### PR TITLE
Align walls with levels

### DIFF
--- a/src/HyparLevelsToObjectsMapper.cs
+++ b/src/HyparLevelsToObjectsMapper.cs
@@ -1,0 +1,54 @@
+﻿using Elements;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpacePlanning
+{
+    internal class HyparLevelsToObjectsMapper : ILevelsToObjectsMapper
+    {
+        private readonly IEnumerable<LevelVolume> _levelVolumes;
+
+        public HyparLevelsToObjectsMapper(IEnumerable<LevelVolume> levelVolumes)
+        {
+            _levelVolumes = levelVolumes;
+        }
+
+        public bool TryMapWallToLevels(Wall wall, Dictionary<string, List<Wall>> wallsByLevel)
+        {
+            // figure out which levels the wall belongs to. Sometimes
+            // walls will have levels attached, otherwise we might have
+            // to infer by geometry.
+            WallLevelInfo levelInfo = null;
+            if (wall.AdditionalProperties.TryGetValue("Levels", out var levels))
+            {
+                levelInfo = WallLevelInfo.FromJObject(levels as JObject);
+            }
+
+            var bottomLevel = _levelVolumes.FirstOrDefault(lv => lv.Level == levelInfo?.BottomLevel.Id);
+            var topLevel = _levelVolumes.FirstOrDefault(lv => lv.Level == levelInfo?.TopLevel.Id);
+            var bottomElevation = bottomLevel?.Transform.Origin.Z ?? 0;
+            var topElevation = topLevel?.Transform.Origin.Z ?? bottomElevation + wall.GetHeight();
+            if (topElevation == bottomElevation)
+            {
+                // in a levels from floors scenario w/ a single level, we'll find the same level for the top and bottom.
+                topElevation += 3;
+            }
+
+            var foundLevelMatch = false;
+            foreach (var lvl in _levelVolumes)
+            {
+                if (lvl.Transform.Origin.Z >= bottomElevation && lvl.Transform.Origin.Z < topElevation - 0.01)
+                {
+                    wallsByLevel[lvl.Id.ToString()].Add(wall);
+                    foundLevelMatch = true;
+                }
+            }
+
+            return foundLevelMatch;
+        }
+    }
+}

--- a/src/ILevelsToObjectsMapper.cs
+++ b/src/ILevelsToObjectsMapper.cs
@@ -1,0 +1,10 @@
+﻿using Elements;
+using System.Collections.Generic;
+
+namespace SpacePlanning
+{
+    internal interface ILevelsToObjectsMapper
+    {
+        public bool TryMapWallToLevels(Wall wall, Dictionary<string, List<Wall>> wallsByLevel);
+    }
+}

--- a/src/RevitLevelsToObjectsMapper.cs
+++ b/src/RevitLevelsToObjectsMapper.cs
@@ -1,0 +1,61 @@
+﻿using Elements;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpacePlanning
+{
+    internal class RevitLevelsToObjectsMapper : ILevelsToObjectsMapper
+    {
+        private readonly IEnumerable<LevelVolume> _levels;
+
+        public RevitLevelsToObjectsMapper(IEnumerable<LevelVolume> levels)
+        {
+            _levels = levels;
+        }
+
+        public bool TryMapWallToLevels(Wall wall, Dictionary<string, List<Wall>> wallsByLevel)
+        {
+            if (!wall.AdditionalProperties.TryGetValue("Base Constraint", out var baseConstraint))
+            {
+                return false;
+            }
+
+            if (baseConstraint == null) 
+            { 
+                return false; 
+            }
+
+            if (!wall.AdditionalProperties.TryGetValue("Top Constraint", out var topConstraint))
+            {
+                return false;
+            }
+
+            string baseLevelName = baseConstraint.ToString();
+            string topLevelName = topConstraint?.ToString();
+
+            bool isBaseFound = false;
+            foreach (var level in _levels)
+            {
+                if (level.Name == baseLevelName)
+                {
+                    isBaseFound = true;
+                }
+
+                if (level.Name == topLevelName)
+                {
+                    break;
+                }
+
+                if (isBaseFound)
+                {
+                    wallsByLevel[level.Id.ToString()].Add(wall);
+                }
+            }
+
+            return isBaseFound;
+        }
+    }
+}

--- a/src/SpacePlanning.cs
+++ b/src/SpacePlanning.cs
@@ -72,10 +72,12 @@ namespace SpacePlanning
 
             var levelGroupedElements = MapElementsToLevels(inputModels, levelVolumes);
 
+            var defaultTransformZ = 0.0;
             var defaultLevelHeight = Units.FeetToMeters(14);
             if (levelGroupedElements.wallsByLevel.TryGetValue("ungrouped", out var ungroupedWalls) && ungroupedWalls.Count > 0)
             {
                 defaultLevelHeight = ungroupedWalls.Max(w => w.GetHeight());
+                defaultTransformZ = ungroupedWalls.Select(w => w.GetCenterline()).Select(l => Math.Min(l.Start.Z, l.End.Z)).Min();
             }
 
             // Get program requirements
@@ -112,7 +114,8 @@ namespace SpacePlanning
                 var dummyLevelVolume = new LevelVolume()
                 {
                     Height = defaultLevelHeight,
-                    AddId = "dummy-level-volume"
+                    AddId = "dummy-level-volume",
+                    Transform = new Transform(0, 0, defaultTransformZ)
                 };
                 var levelLayout = new LevelLayout(dummyLevelVolume, levelGroupedElements);
                 levelLayouts.Add(levelLayout);

--- a/src/SpacePlanning.cs
+++ b/src/SpacePlanning.cs
@@ -334,11 +334,24 @@ namespace SpacePlanning
             }
             wallsByLevel.Add("ungrouped", new List<Wall>());
 
-            ILevelsToObjectsMapper levelsToObjectsMapper = new HyparLevelsToObjectsMapper(levelVolumes);
+            var levelToObjectsMappers = new List<ILevelsToObjectsMapper>()
+            {
+                new HyparLevelsToObjectsMapper(levelVolumes),
+                new RevitLevelsToObjectsMapper(levelVolumes)
+            };
 
             foreach (var wall in walls)
             {
-                var foundLevelMatch = levelsToObjectsMapper.TryMapWallToLevels(wall, wallsByLevel);
+                var foundLevelMatch = false;
+
+                foreach (var mapper in levelToObjectsMappers)
+                {
+                    if (mapper.TryMapWallToLevels(wall, wallsByLevel))
+                    {
+                        foundLevelMatch = true;
+                        break;
+                    }
+                }
 
                 if (!foundLevelMatch)
                 {


### PR DESCRIPTION
BACKGROUND:
 - Lines of space boundaries were not aligned with walls and level volumes.

DESCRIPTION:
 - Aligned dummy volume level with ungrouped wall lines min Z.
 - Wall properties "Base Constraint" and "Top Constraint" extracted from Revit are now used to map level volumes to walls.

TESTING:
 - Tested on https://hypar.io/workflows/30abf136-8dfe-40c0-9b03-2cd6b4bbaf40.