### PR TITLE
Exclude inner rooms from enclosed rooms

### DIFF
--- a/dependencies/LevelLayout.cs
+++ b/dependencies/LevelLayout.cs
@@ -157,7 +157,27 @@ namespace Elements
             {
                 // swallow
             }
+
+            ExcludeInnerPolygons(enclosedRooms);
             return (subtractedProfiles, enclosedRooms);
+        }
+
+        private static void ExcludeInnerPolygons(List<Profile> profiles)
+        {
+            var orderedByAreaProfiles = profiles.OrderByDescending(p => p.Area()).ToList();
+
+            for (int i = 0; i < orderedByAreaProfiles.Count; i++)
+            {
+                var outerCandidate = orderedByAreaProfiles[i];
+                for (int j = i + 1; j < orderedByAreaProfiles.Count; j++)
+                {
+                    var innerCandidate = orderedByAreaProfiles[j];
+                    if (outerCandidate.Perimeter.Covers(innerCandidate.Perimeter))
+                    {
+                        outerCandidate.Voids.Add(innerCandidate.Perimeter.Reversed());
+                    }
+                }
+            }
         }
 
         private LevelElements _levelElements = null;


### PR DESCRIPTION
BACKGROUND:
 - Space boundaries contained areas of the inner space boundaries.

DESCRIPTION:
 - Removed areas of space boundaries from the profiles of space boundaries that contain them.

TESTING:
 - Tested on workflow https://hypar.io/workflows/30abf136-8dfe-40c0-9b03-2cd6b4bbaf40.