### PR TITLE
Lower-space-height

### DIFF
--- a/dependencies/SpaceBoundary.cs
+++ b/dependencies/SpaceBoundary.cs
@@ -220,7 +220,8 @@ namespace Elements
             {
                 // just swallow an offset failure.
             }
-            var extrude = new Extrude(innerProfile.Transformed(new Transform(0, 0, 0.001)), Height, Vector3.ZAxis)
+            // Representation height should be dropped a bit to account for view scope overlap. TODO: In the future, our SpaceBoundaries should be reactive to the floor depth of the level above... or perhaps ceiling height (tbd)
+            var extrude = new Extrude(innerProfile.Transformed(new Transform(0, 0, 0.001)), Height - 0.001, Vector3.ZAxis)
             {
                 ReverseWinding = true
             };

--- a/dependencies/SpaceBoundary.cs
+++ b/dependencies/SpaceBoundary.cs
@@ -221,7 +221,7 @@ namespace Elements
                 // just swallow an offset failure.
             }
             // Representation height should be dropped a bit to account for view scope overlap. TODO: In the future, our SpaceBoundaries should be reactive to the floor depth of the level above... or perhaps ceiling height (tbd)
-            var extrude = new Extrude(innerProfile.Transformed(new Transform(0, 0, 0.001)), Height - 0.001, Vector3.ZAxis)
+            var extrude = new Extrude(innerProfile.Transformed(new Transform(0, 0, 0.001)), Height - 0.01, Vector3.ZAxis)
             {
                 ReverseWinding = true
             };

--- a/src/Function.g.cs
+++ b/src/Function.g.cs
@@ -71,7 +71,6 @@ namespace SpacePlanning
                     this.store = new UrlModelStore<SpacePlanningInputs>();
                 }
             }
-            
 
             var l = new InvocationWrapper<SpacePlanningInputs,SpacePlanningOutputs> (store, SpacePlanning.Execute);
             var output = await l.InvokeAsync(args);


### PR DESCRIPTION
lower the SpaceBoundary extrusion so we don't click the wrong level accidentally when double clicking in the view scope