### PR TITLE
support wall types

### DIFF
--- a/dependencies/LevelVolume.g.cs
+++ b/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/dependencies/ProgramRequirement.cs
+++ b/dependencies/ProgramRequirement.cs
@@ -7,6 +7,9 @@ namespace Elements
     {
         public bool? Enclosed { get; set; }
         public int CountPlaced { get; set; }
+
+        [JsonProperty("Default Wall Type")]
+        public string DefaultWallType { get; set; }
         public int RemainingToPlace
         {
             get

--- a/dependencies/SpaceBoundary.cs
+++ b/dependencies/SpaceBoundary.cs
@@ -301,6 +301,7 @@ namespace Elements
                 fullReq.CountPlaced++;
                 sb.FulfilledProgramRequirement = fullReq;
                 sb.ProgramGroup = fullReq.ProgramGroup;
+                sb.DefaultWallType = fullReq.DefaultWallType;
             }
             sb.ProgramName = fullyQualifiedName;
             sb.ParentCentroid = xform.OfPoint(profile.Perimeter.Centroid());
@@ -353,10 +354,11 @@ namespace Elements
                 fullReq.CountPlaced++;
                 this.FulfilledProgramRequirement = fullReq;
                 this.ProgramRequirement = fullReq.Id;
-                if (fullReq.Enclosed == true && this.Boundary.GetEdgeThickness() == null)
+                if ((fullReq.Enclosed == true || fullReq.DefaultWallType == "Solid" || fullReq.DefaultWallType == "Glass") && this.Boundary.GetEdgeThickness() == null)
                 {
                     this.Boundary.SetEdgeThickness(Units.InchesToMeters(3), Units.InchesToMeters(3));
                 }
+                this.DefaultWallType = fullReq.DefaultWallType;
             }
             this.ProgramType = displayName;
         }

--- a/dependencies/SpaceBoundary.g.cs
+++ b/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/src/Function.g.cs
+++ b/src/Function.g.cs
@@ -71,6 +71,7 @@ namespace SpacePlanning
                     this.store = new UrlModelStore<SpacePlanningInputs>();
                 }
             }
+            
 
             var l = new InvocationWrapper<SpacePlanningInputs,SpacePlanningOutputs> (store, SpacePlanning.Execute);
             var output = await l.InvokeAsync(args);


### PR DESCRIPTION
Support attaching `Default Wall Type` from the program requirement to the space. Downstream layout functions will use this to decide what wall type to use. see https://github.com/hypar-io/HyparSpace/pull/67

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Function-SpacePlanning/11)
<!-- Reviewable:end -->
